### PR TITLE
Ensure dotenv loads the .env file to set project root

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ if defined?(Bundler)
   # Bundler.require *Rails.groups(:assets => %w(development test))
   # If you want your assets lazily compiled in production, use this line
   Bundler.require(:default, Rails.env)
+  Bundler.require(*Rails.groups)
+
+  Dotenv::Railtie.load
 end
 
 # Note, .dev TLD won't be accepted by Google OAuth callbacks, you'll need


### PR DESCRIPTION
According to [the readme](https://github.com/bkeepers/dotenv#note-on-load-order), you may need to load the env variables in the bootstrapping process in case that it is necessary.

Without this, the site root will be available to the application if modified, but will return `nil` at config time.
